### PR TITLE
Bump NodeJS version from 20 to 24 +semver: minor

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
   contents:
     description: 'The file contents.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## 📑 Description
Bump NodeJS version from 20 to 24

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Build:
- Bump the GitHub Action runner configuration from node20 to node24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Action runtime to Node.js 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->